### PR TITLE
[7주차] 지영 Count Almost Equal Pairs 문제 풀이 PR

### DIFF
--- a/S04/week07/z0/CountAlmostEqualPairs.kt
+++ b/S04/week07/z0/CountAlmostEqualPairs.kt
@@ -1,0 +1,52 @@
+class Solution {
+    // Runtime: 408ms(31.71%)
+    // Memory: 45.30MB(21.95%)
+    // Time taken: 1 hr 44 m 50 s
+    fun countPairs(nums: IntArray): Int {
+        var count = 0
+        for (i in nums.indices) {
+            for (j in i + 1 until nums.size) {
+                if (isAlmostEqual(nums[i], nums[j])) {
+                    count++
+                }
+            }
+        }
+        return count
+    }
+
+    private fun isAlmostEqual(n1: Int, n2: Int): Boolean {
+        var x = n1.toString()
+        var y = n2.toString()
+        // 더 짧은 String 앞에 더 긴 string의 length 만큼 '0'을 추가 
+        if (x.length < y.length) {
+            x = x.padStart(y.length, '0')
+        } else {
+            y = y.padStart(x.length, '0')
+        }
+
+        val indexes = mutableListOf<Int>()
+        for (i in 0..x.lastIndex) {
+            if (x[i] != y[i]) { // 같은 index에 있는 char 끼리 비교
+                indexes.add(i) // 서로 다르면 indexes 리스트에 저장
+            }
+            if (indexes.size > 2) { // indexes가 2보다 클 경우 한번의 swap으로는 같은 값을 만들 수 없기 때문에 false 리턴
+                return false
+            }
+        }
+
+        if (indexes.size == 0) { // x와 y가 같다는 의미이므로 true 리턴
+            return true
+        }
+        
+        // 서로 다른 index swap 시작
+        if (indexes.size == 2) {
+            val xCopy = x.toCharArray()
+            val temp = xCopy[indexes[0]]
+            xCopy[indexes[0]] = xCopy[indexes[1]]
+            xCopy[indexes[1]] = temp
+
+            return (xCopy.joinToString(separator="") == y) // swap한 x가 y와 같으면 almost equal
+        }
+        return false // 그 외 케이스는 모두 false
+    }
+}


### PR DESCRIPTION
# 문제
첫번째 문제 : [Count Almost Equal Pairs I](https://leetcode.com/problems/count-almost-equal-pairs-i/)

#해설
처음에 문제 이해를 잘못해서 시간이 좀 걸렸습니다;
한번의 swap으로 x와 y가 같아질 수 있는 almost equal 숫자의 갯수를 찾는다. 한번의 swap으로 두 숫자가 같아지려면 x와 y를 비교했을 때 다른 char의 index 갯수가 2보다 작아야한다. 자세한 내용은 주석 참고.

(문제에서 이해가 좀 안되는게, x == y 인 경우에도 almost equal로 취급하는게 이해가 좀 안되네요..문제에는 한번의 swap으로 같아지는 수를 말한다고 밖에 설명이 안되어있는데,, 다른 분들은 어떻게 풀이 하셨는지 참고해보겠습니다.)