### PR TITLE
[8주차] 석준 Minimum Recolors to Get K Consecutive Black Blocks 문제 풀이 PR

### DIFF
--- a/S04/week08/seokjoon/MinimumRecolorstoGetKConsecutiveBlackBlocks.kt
+++ b/S04/week08/seokjoon/MinimumRecolorstoGetKConsecutiveBlackBlocks.kt
@@ -1,0 +1,20 @@
+class Solution {
+    fun minimumRecolors(blocks: String, k: Int): Int {
+        var answer = k  
+
+        //for 문을 돌면서 모든 경우를 탐색한다. 
+        for (i in 0..blocks.length - k) {
+            var current = 0
+            //i 부터 길이 k만큼 구간에서 W의 개수를 구한다.
+            for (j in i until i + k) {
+                if (blocks[j] == 'W') {
+                    current++
+                }
+            }
+            // 최소값 갱신
+            answer = minOf(answer, current)
+        }
+        
+        return answer
+    }
+}


### PR DESCRIPTION
# 문제
모의테스트 첫번째 문제 : [2379. Minimum Recolors to Get K Consecutive Black Blocks](https://leetcode.com/problems/minimum-recolors-to-get-k-consecutive-black-blocks/)

# 풀이
n이 최대 100이기 때문에 모든 경우를 돌면서 k길이의 구간만큼의 W의 개수를 구하고 최소값을 찾습니다.