### PR TITLE
[8주차] 승희 Minimum Recolors to Get K Consecutive Black Blocks 문제 풀이 PR

### DIFF
--- a/S04/week08/s0ng2/minimum_recolors.kt
+++ b/S04/week08/s0ng2/minimum_recolors.kt
@@ -1,0 +1,24 @@
+class Solution {
+    fun minimumRecolors(blocks: String, k: Int): Int {
+        val totalBlocks = blocks.length
+        val maxStartIndex = totalBlocks - k
+        var minOperations = Int.MAX_VALUE
+
+        // 각 가능한 시작 지점에 대해 순회
+        for (start in 0..maxStartIndex) {
+            var whiteCount = 0
+            
+            // k개 연속 블록을 검사
+            for (i in start until start + k) {
+                if (blocks[i] == 'W') {
+                    whiteCount++
+                }
+            }
+            
+            // 최소 교체 횟수 업데이트
+            minOperations = minOf(minOperations, whiteCount)
+        }
+        
+        return minOperations
+    }
+}


### PR DESCRIPTION
## 문제
[2379. Minimum Recolors to Get K Consecutive Black Blocks](https://leetcode.com/problems/minimum-recolors-to-get-k-consecutive-black-blocks/)

## 풀이
슬라이딩 윈도우 방식으로 문자열을 순차적으로 확인하면서 k개의 블록 내에서 흰 블록('W')의 개수를 세고, 그 중 최소값을 찾습니답